### PR TITLE
Added Hue Debugger UI to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 ##NodeJS
 * [node-hue-api](https://github.com/peter-murray/node-hue-api) by Peter Murray 
 * [hue-module](https://github.com/whyohwhyamihere/hue-module) by Chris Anderson
+* [Hue Debugger UI](https://hue-debugger-ui.com) by [Silind Software](https://github.com/Silind)
 
 ##Objective-C
 * [Official Hue SDK for iOS](https://github.com/PhilipsHue/PhilipsHueSDKiOS) by Philips


### PR DESCRIPTION
Added Hue Debugger UI to this list.
The tool is added on Philips Hue Developer page under Tools and SDKs, so I thought I'd updated this list as well :)

You can check out the project here:
https://hue-debugger-ui.com